### PR TITLE
enables fetch

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module MarkitoffApi
     config.middleware.insert_before 0, "Rack::Cors" do
       allow do
         origins '*'
-        resource '*', :headers => :any, :methods => [:get, :post, :options]
+        resource '*', :headers => :any, :methods => [:get, :post, :patch, :options]
       end
     end
 


### PR DESCRIPTION
The problem is that we never enable the ability for clients (your front end react app) to make a `:patch` to the API. I highly recommend reading about CORS and why this is neccessary.

You can will be able to update todos if you merge this. 